### PR TITLE
Wrap the SDK into a gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.iml
+*.idea
+Gemfile.lock
+*.gem
+spec/dummy/config.rb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,66 @@
-sdk-ruby
-========
+# Ruby gem for LiqPay.com API
 
-LiqPay SDK-RUBY 
+Ruby gem wrapper for official Liqpay SDK https://github.com/liqpay/sdk-ruby
 
-Documentation https://www.liqpay.com/ru/doc
+## Installation
+
+Add the gem to your Gemfile:
+
+```ruby
+gem 'novaposhta2', github: 'kukareka/novaposhta2'
+```
+
+And don't forget to run Bundler:
+
+```shell
+$ bundle install
+```
+
+## Configuration
+
+Get API keys on https://www.liqpay.com/ and save them in config:
+ 
+```ruby
+# config/initializers/liqpay.rb
+
+::Liqpay.configure do |config|
+  config.public_key = 'public_key'
+  config.private_key = 'private_key'
+end
+```
+
+You can also store API keys in `ENV['LIQPAY_PUBLIC_KEY']` and `ENV['LIQPAY_PRIVATE_KEY']`
+
+## Usage
+
+```ruby
+require 'liqpay'
+liqpay = Liqpay.new
+liqpay.api 'invoice/send', { email: 'test@example.com', amount: 100, currency: 'UAH',
+  order_id: 1,
+  goods: [{
+              amount: 100,
+              count: 1,
+              unit: 'pcs',
+              name: 'Order' }]}
+```
+
+Full Liqpay API documentation is available on https://www.liqpay.com/en/doc
+
+## Tests
+
+To pass the API tests, specify API keys in `ENV['LIQPAY_PUBLIC_KEY']` and `ENV['LIQPAY_PRIVATE_KEY']`
+or in `spec/dummy/config.rb`:
+
+```ruby
+# spec/dummy/config.rb
+::Liqpay.configure do |config|
+  config.public_key = 'public_key'
+  config.private_key = 'private_key'
+end
+```
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ruby gem wrapper for official Liqpay SDK https://github.com/liqpay/sdk-ruby
 Add the gem to your Gemfile:
 
 ```ruby
-gem 'novaposhta2', github: 'kukareka/novaposhta2'
+gem 'liqpay', github: 'kukareka/liqpay'
 ```
 
 And don't forget to run Bundler:

--- a/lib/liqpay.rb
+++ b/lib/liqpay.rb
@@ -1,0 +1,19 @@
+require 'liqpay/config'
+require 'liqpay/client'
+require 'liqpay/coder'
+require 'liqpay/liqpay'
+
+module Liqpay
+  def self.config # :nodoc:
+    @config ||= ::Liqpay::Config.new
+  end
+
+  def self.new(*options)
+    ::Liqpay::Liqpay.new(*options)
+  end
+
+  def self.configure # :nodoc:
+    yield config
+    @config
+  end
+end

--- a/lib/liqpay/client.rb
+++ b/lib/liqpay/client.rb
@@ -12,7 +12,7 @@ module Liqpay
     end
 
     def http_request(path, body)
-      url = @url << path
+      url = @url + path
       uri = URI.parse(url)
       timeout = 60
 

--- a/lib/liqpay/config.rb
+++ b/lib/liqpay/config.rb
@@ -1,0 +1,12 @@
+module Liqpay
+  class Config
+    attr_accessor :private_key, :public_key, :version, :server_url, :return_url
+
+    def initialize
+      @private_key = ENV['LIQPAY_PRIVATE_KEY']
+      @public_key = ENV['LIQPAY_PUBLIC_KEY']
+      @version = 3
+    end
+
+  end
+end

--- a/lib/liqpay/liqpay.rb
+++ b/lib/liqpay/liqpay.rb
@@ -28,12 +28,15 @@ module Liqpay
     def initialize(options = {})
       @host = 'https://www.liqpay.com/api/'
       options[:host] = @host
-      @public_key = options[:public_key] if options.key? :public_key
-      @private_key = options[:private_key] if options.key?  :private_key
+      @public_key = options[:public_key] || ::Liqpay.config.public_key
+      @private_key = options[:private_key] || ::Liqpay.config.private_key
       @client = Client.new(options)
     end
 
     def api(path, params)
+      params[:version] ||= ::Liqpay.config.version.to_s
+      params[:server_url] ||= ::Liqpay.config.server_url
+      params[:return_url] ||= ::Liqpay.config.return_url
       fail "Version can't be empty" if params[:version].nil? or params[:version].empty?
       params[:public_key] = @public_key
       json_params = Coder.encode64 Coder.encode_json params

--- a/liqpay.gemspec
+++ b/liqpay.gemspec
@@ -1,0 +1,17 @@
+Gem::Specification.new do |s|
+  s.name        = 'liqpay'
+  s.version     = '0.0.1'
+  s.platform    = Gem::Platform::RUBY
+  s.authors     = ['Oleg Kukareka']
+  s.email       = 'oleg@kukareka.com'
+  s.homepage    = 'https://github.com/kukareka/liqpay'
+  s.summary     = 'LiqPay.com Ruby SDK'
+  s.description = 'Gem wrapper for official liqpay/sdk-ruby'
+  s.homepage    = 'https://github.com/kukareka/liqpay'
+  s.required_ruby_version = '>= 1.9'
+
+  s.rubyforge_project         = 'liqpay'
+
+  s.files        = Dir['{lib}/**/*.rb']
+  s.require_path = 'lib'
+end

--- a/spec/classes/api/invoice_spec.rb
+++ b/spec/classes/api/invoice_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+begin
+require File.expand_path('../../../dummy/config.rb', __FILE__) unless ENV['LIQPAY_PUBLIC_KEY'] && ENV['LIQPAY_PRIVATE_KEY']
+rescue LoadError
+  puts "Could not load API keys. Please provide API keys in ENV['LIQPAY_PUBLIC_KEY'] && ENV['LIQPAY_PRIVATE_KEY'] or spec/dummy/config.rb"
+end
+
+module Liqpay
+ describe 'Invoice API' do
+   before :all do
+     @liqpay = Liqpay.new
+   end
+   it 'should be able to send and cancel invoices' do
+     order_id = rand(1000)
+     r = @liqpay.api 'invoice/send', { email: 'test@example.com', amount: 100, currency: 'UAH',
+                                   order_id: order_id,
+                                   goods: [{
+                                               amount: 100,
+                                               count: 1,
+                                               unit: 'Order',
+                                               name: "Order #{order_id}" }]}
+     expect(r['result']).to eq 'ok'
+     r = @liqpay.api 'invoice/cancel', {order_id: order_id}
+     expect(r['result']).to eq 'ok'
+
+   end
+ end
+end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+module Liqpay
+  describe ::Liqpay::Config do
+    before :each do
+      ::Liqpay.configure do |c|
+        c.private_key = 'private_key'
+        c.public_key = 'public_key'
+      end
+    end
+
+    it 'should have private key' do
+      expect(::Liqpay.config.private_key).to eq 'private_key'
+    end
+
+    it 'should have public key' do
+      expect(::Liqpay.config.public_key).to eq 'public_key'
+    end
+
+    it 'should reflect changes through block' do
+      ::Liqpay.configure do |c|
+        c.private_key = 'private_key3'
+      end
+      expect(::Liqpay.config.private_key).to eq 'private_key3'
+    end
+  end
+
+end
+

--- a/spec/classes/liqpay_spec.rb
+++ b/spec/classes/liqpay_spec.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
+require 'spec_helper'
 
-require './lib/liqpay/liqpay'
-require './lib/liqpay/client'
-require './lib/liqpay/coder'
 
 describe :cnd_form do
   let(:liqpay_empty) { Liqpay::Liqpay.new(
@@ -14,6 +12,12 @@ describe :cnd_form do
     :public_key  => 'public_key'
   )}
   context 'when creating form' do
+    before :all do
+      ::Liqpay.configure do |c|
+        c.version = nil
+        c.private_key = nil
+      end
+    end
     it 'does not create form without version field' do
       expect {
         Liqpay::Liqpay.new.cnb_form()

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'liqpay'


### PR DESCRIPTION
Add some configuration options, let one `Liqpay` instance to make multiple requests, wrap the SDK into a gem to make it available via `Gemfile`:

```ruby
# Gemfile
gem 'liqpay', github: 'liqpay/sdk-ruby'

# config/initializers/liqpay.rb
::Liqpay.configure do |config|
  config.public_key = 'public_key'
  config.private_key = 'private_key'
end
```